### PR TITLE
small config change

### DIFF
--- a/js/radar.js
+++ b/js/radar.js
@@ -159,7 +159,7 @@ const RadarMap = (() => {
 
         map = L.map('radar-map', {
             center: [lat, lon],
-            zoom: 4,
+            zoom: 10,
             zoomControl: true,
             attributionControl: true,
             scrollWheelZoom: true


### PR DESCRIPTION
This pull request makes a minor adjustment to the initial zoom level of the radar map, increasing it for a more detailed default view.

* Increased the default `zoom` level from 4 to 10 in the `RadarMap` initialization within `js/radar.js` to provide a closer, more detailed map view.