### PR TITLE
Add permalink feature and refactor settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,22 @@
             <p class="hint-text">Fullscreen, hides all controls. Press <kbd>Esc</kbd> to exit.</p>
             <button id="kiosk-btn" class="btn-kiosk">⛶ Enter Kiosk Mode</button>
         </section>
+
+        <!-- Permalink -->
+        <section class="settings-section">
+            <h3>🔗 Permalink</h3>
+            <p class="hint-text">Create a link that restores your current settings and location.</p>
+            <div class="toggle-row">
+                <span>Start in Kiosk mode</span>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="permalink-kiosk-toggle" />
+                    <span class="toggle-slider"></span>
+                </label>
+            </div>
+            <button id="btn-copy-permalink" class="btn-primary" style="width: 100%; margin-top: 10px;">📋 Copy
+                Permalink</button>
+            <div id="permalink-status" class="status-text" style="text-align: center; margin-top: 5px;"></div>
+        </section>
     </aside>
 
     <!-- ═══════════════════════════════════════════════

--- a/js/settings.js
+++ b/js/settings.js
@@ -146,7 +146,7 @@ const Settings = (() => {
     }
 
     // ── TTS & Duck toggles ─────────────────────────────────────────
-    function getTTSEnabled() { return document.getElementById('tts-toggle')?.checked ?? true; }
+    function getTTSEnabled() { return document.getElementById('tts-toggle')?.checked ?? false; }
     function getDuckEnabled() { return document.getElementById('duck-toggle')?.checked ?? true; }
 
     function bindAlertToggles() {
@@ -205,25 +205,28 @@ const Settings = (() => {
     }
 
     // ── Persistence ────────────────────────────────────────────────
+    function getState() {
+        const suppressedTypes = [];
+        document.querySelectorAll('[data-tts-type]').forEach(cb => {
+            if (!cb.checked) suppressedTypes.push(cb.dataset.ttsType);
+        });
+
+        return {
+            theme: currentTheme,
+            units: document.getElementById('unit-toggle')?.checked ? 'celsius' : 'fahrenheit',
+            speed: document.getElementById('speed-slider')?.value || 12,
+            displays: getActiveDisplays(),
+            volume: document.getElementById('volume-slider')?.value || 40,
+            tts: document.getElementById('tts-toggle')?.checked ?? true,
+            duck: document.getElementById('duck-toggle')?.checked ?? true,
+            shuffle: document.getElementById('shuffle-toggle')?.checked ?? true,
+            suppressedTtsTypes: suppressedTypes
+        };
+    }
+
     function saveToStorage() {
         try {
-            // Collect suppressed types (unchecked boxes)
-            const suppressedTypes = [];
-            document.querySelectorAll('[data-tts-type]').forEach(cb => {
-                if (!cb.checked) suppressedTypes.push(cb.dataset.ttsType);
-            });
-
-            const state = {
-                theme: currentTheme,
-                units: document.getElementById('unit-toggle')?.checked ? 'celsius' : 'fahrenheit',
-                speed: document.getElementById('speed-slider')?.value || 12,
-                displays: getActiveDisplays(),
-                volume: document.getElementById('volume-slider')?.value || 40,
-                tts: document.getElementById('tts-toggle')?.checked ?? true,
-                duck: document.getElementById('duck-toggle')?.checked ?? true,
-                shuffle: document.getElementById('shuffle-toggle')?.checked ?? true,
-                suppressedTtsTypes: suppressedTypes
-            };
+            const state = getState();
             localStorage.setItem('weathernow_settings', JSON.stringify(state));
         } catch { }
     }
@@ -290,5 +293,5 @@ const Settings = (() => {
         return parseInt(document.getElementById('speed-slider')?.value || 12) * 1000;
     }
 
-    return { init, openPanel, closePanel, getActiveDisplays, bindDisplayToggles, getSpeed, saveToStorage };
+    return { init, openPanel, closePanel, getActiveDisplays, bindDisplayToggles, getSpeed, saveToStorage, getState, enterKiosk };
 })();

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# 1. Start the virtual display (1920x1080 resolution)
+Xvfb :99 -screen 0 1920x1080x24 &
+export DISPLAY=:99
+
+# 2. Start a tiny window manager so the browser stays fullscreen
+fluxbox &
+
+# 3. Launch the browser in kiosk mode (fullscreen, no UI)
+chromium-browser --no-sandbox --kiosk --window-position=0,0 --window-size=1920,1080 "https://weather.evaakselrad.com/" &
+
+# Wait a few seconds for the page to load
+sleep 10
+
+# 4. Use FFmpeg to grab the virtual display and push to YouTube
+ffmpeg -f x11grab -video_size 1920x1080 -i :99.0 \
+    -f alsa -i default -c:v libx264 -preset veryfast \
+    -b:v 3000k -maxrate 3000k -bufsize 6000k \
+    -pix_fmt yuv420p -g 60 -c:a aac -b:a 128k \
+    -f flv "rtmp://a.rtmp.youtube.com/live2/sphz-txx6-qepe-grmh-8m8q"


### PR DESCRIPTION
Add a Permalink UI and copy action that encodes current settings, location and a kiosk flag into a base64 query param (s) and copies a cleaned URL to the clipboard. On boot the app now processes the permalink param, restores settings/location into localStorage, optionally auto-enters kiosk mode, and removes the s param from the URL. Refactor settings persistence by extracting getState to collect suppressed TTS types and other prefs, and reuse it in saveToStorage. Change default TTS toggle behavior to false, and expose getState and enterKiosk from Settings. Add test.txt: a helper script to run a headless Xvfb/fluxbox Chromium kiosk and stream the display via ffmpeg to YouTube.